### PR TITLE
Fix for saving all attachments from them messages.

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -701,7 +701,7 @@ class Message {
         $oAttachment = new Attachment($this, $part);
 
         if ($oAttachment->getName() !== null && $oAttachment->getSize() > 0) {
-            if ($oAttachment->getId() !== null) {
+            if ($oAttachment->getId() !== null && $this->attachments->offsetExists($oAttachment->getId())) {
                 $this->attachments->put($oAttachment->getId(), $oAttachment);
             } else {
                 $this->attachments->push($oAttachment);


### PR DESCRIPTION
There was a problem with fetch all attachments. Some attachments are not added to the collection. Checking attachment ID before add it to collection solved the problem in my case.